### PR TITLE
CLDR-15878 fixes to Esperanto

### DIFF
--- a/common/main/eo.xml
+++ b/common/main/eo.xml
@@ -60,7 +60,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<language type="bo">tibeta</language>
 			<language type="br">bretona</language>
 			<language type="brx" draft="unconfirmed">bodoa</language>
-			<language type="bs" draft="contributed">bosnia</language>
+			<language type="bs" draft="unconfirmed">bosna</language>
 			<language type="bug" draft="unconfirmed">buĝia</language>
 			<language type="byn" draft="unconfirmed">bilena</language>
 			<language type="ca">kataluna</language>
@@ -104,7 +104,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<language type="doi" draft="unconfirmed">dogra</language>
 			<language type="dsb" draft="unconfirmed">malsuprasoraba</language>
 			<language type="dua" draft="unconfirmed">dualaa</language>
-			<language type="dv">mahla</language>
+			<language type="dv" draft="unconfirmed">maldiva</language>
 			<language type="dyo" draft="unconfirmed">djola</language>
 			<language type="dz">dzonko</language>
 			<language type="dzg" draft="unconfirmed">dazaa</language>
@@ -120,7 +120,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<language type="en_GB" alt="short" draft="unconfirmed">↑↑↑</language>
 			<language type="en_US" draft="unconfirmed">angla usona</language>
 			<language type="en_US" alt="short" draft="unconfirmed">↑↑↑</language>
-			<language type="eo">esperanto</language>
+			<language type="eo">Esperanto</language>
 			<language type="es">hispana</language>
 			<language type="es_419" draft="unconfirmed">hispana amerika</language>
 			<language type="es_ES" draft="unconfirmed">hispana eŭropa</language>
@@ -142,10 +142,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<language type="frc" draft="unconfirmed">kaĵun-franca</language>
 			<language type="frr" draft="unconfirmed">nord-frisa</language>
 			<language type="fur" draft="unconfirmed">friula</language>
-			<language type="fy">frisa</language>
+			<language type="fy" draft="unconfirmed">okcident-frisa</language>
 			<language type="ga">irlanda</language>
 			<language type="gaa" draft="unconfirmed">↑↑↑</language>
-			<language type="gd">gaela</language>
+			<language type="gd" draft="unconfirmed">skot-gaela</language>
 			<language type="gez" draft="unconfirmed">geeza</language>
 			<language type="gil" draft="unconfirmed">kiribata</language>
 			<language type="gl">galega</language>
@@ -173,11 +173,11 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<language type="hur" draft="unconfirmed">halkomelema</language>
 			<language type="hy">armena</language>
 			<language type="hz" draft="unconfirmed">herera</language>
-			<language type="ia">interlingvao</language>
+			<language type="ia" draft="unconfirmed">Interlingvao</language>
 			<language type="iba" draft="unconfirmed">ibana</language>
 			<language type="ibb" draft="unconfirmed">ibibia</language>
 			<language type="id">indonezia</language>
-			<language type="ie">okcidentalo</language>
+			<language type="ie" draft="unconfirmed">Interlingveo</language>
 			<language type="ig" draft="unconfirmed">igba</language>
 			<language type="ii" draft="unconfirmed">jia</language>
 			<language type="ik">eskima</language>
@@ -318,10 +318,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<language type="pis" draft="unconfirmed">piĵina</language>
 			<language type="pl">pola</language>
 			<language type="pqm" draft="unconfirmed">malesita-pasamakvodja</language>
-			<language type="ps">paŝtoa</language>
+			<language type="ps" draft="unconfirmed">paŝtua</language>
 			<language type="pt">portugala</language>
-			<language type="pt_BR">brazilportugala</language>
-			<language type="pt_PT">eŭropportugala</language>
+			<language type="pt_BR" draft="unconfirmed">portugala brazila</language>
+			<language type="pt_PT" draft="unconfirmed">portugala eŭropa</language>
 			<language type="qu">keĉua</language>
 			<language type="raj" draft="unconfirmed">raĝastana</language>
 			<language type="rap" draft="unconfirmed">rapanuia</language>
@@ -390,7 +390,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<language type="tlh" draft="contributed">klingona</language>
 			<language type="tli" draft="unconfirmed">tlingita</language>
 			<language type="tn">cvana</language>
-			<language type="to">tongaa</language>
+			<language type="to" draft="unconfirmed">tongana</language>
 			<language type="tok" draft="unconfirmed">Tokipono</language>
 			<language type="tpi" draft="unconfirmed">Tokpisino</language>
 			<language type="tr">turka</language>
@@ -413,7 +413,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<language type="vai" draft="unconfirmed">vaja</language>
 			<language type="ve" draft="unconfirmed">vendaa</language>
 			<language type="vi">vjetnama</language>
-			<language type="vo">volapuko</language>
+			<language type="vo" draft="unconfirmed">Volapuko</language>
 			<language type="vun" draft="unconfirmed">kivunja</language>
 			<language type="wa" draft="unconfirmed">valona</language>
 			<language type="wae" draft="unconfirmed">germana valza</language>
@@ -490,7 +490,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<script type="Zzzz" draft="unconfirmed">nekonata skribsistemo</script>
 		</scripts>
 		<territories>
-			<territory type="001">Mondo</territory>
+			<territory type="001">mondo</territory>
 			<territory type="002" draft="unconfirmed">Afriko</territory>
 			<territory type="003" draft="unconfirmed">Nordameriko</territory>
 			<territory type="005" draft="unconfirmed">Sudameriko</territory>
@@ -525,7 +525,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<territory type="AD">Andoro</territory>
 			<territory type="AE">Unuiĝintaj Arabaj Emirlandoj</territory>
 			<territory type="AF">Afganujo</territory>
-			<territory type="AG">Antigvo-Barbudo</territory>
+			<territory type="AG" draft="unconfirmed">Antigvo kaj Barbudo</territory>
 			<territory type="AI">Angvilo</territory>
 			<territory type="AL">Albanujo</territory>
 			<territory type="AM">Armenujo</territory>
@@ -538,7 +538,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<territory type="AW">Arubo</territory>
 			<territory type="AX" draft="unconfirmed">Alando</territory>
 			<territory type="AZ">Azerbajĝano</territory>
-			<territory type="BA">Bosnio-Hercegovino</territory>
+			<territory type="BA" draft="unconfirmed">Bosnujo kaj Hercegovino</territory>
 			<territory type="BB">Barbado</territory>
 			<territory type="BD">Bangladeŝo</territory>
 			<territory type="BE">Belgujo</territory>
@@ -564,7 +564,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<territory type="CD" draft="unconfirmed">Kongo Kinŝasa</territory>
 			<territory type="CD" alt="variant" draft="unconfirmed">Demokratia Respubliko Kongo</territory>
 			<territory type="CF">Centr-Afrika Respubliko</territory>
-			<territory type="CG">Kongolo</territory>
+			<territory type="CG" draft="unconfirmed">Kongo Brazavila</territory>
 			<territory type="CG" alt="variant" draft="unconfirmed">Respubliko Kongo</territory>
 			<territory type="CH">Svisujo</territory>
 			<territory type="CI">Ebur-Bordo</territory>
@@ -577,7 +577,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<territory type="CP" draft="unconfirmed">Klipertono</territory>
 			<territory type="CR">Kostariko</territory>
 			<territory type="CU">Kubo</territory>
-			<territory type="CV">Kabo-Verdo</territory>
+			<territory type="CV" draft="unconfirmed">Kaboverdo</territory>
 			<territory type="CW" draft="unconfirmed">Kuracao</territory>
 			<territory type="CX" draft="unconfirmed">Kristnaskinsulo</territory>
 			<territory type="CY">Kipro</territory>
@@ -593,7 +593,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<territory type="EA" draft="unconfirmed">Ceŭto kaj Melilo</territory>
 			<territory type="EC">Ekvadoro</territory>
 			<territory type="EE">Estonujo</territory>
-			<territory type="EG">Egipto</territory>
+			<territory type="EG" draft="unconfirmed">Egiptujo</territory>
 			<territory type="EH">Okcidenta Saharo</territory>
 			<territory type="ER">Eritreo</territory>
 			<territory type="ES">Hispanujo</territory>
@@ -652,21 +652,21 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<territory type="JO">Jordanio</territory>
 			<territory type="JP">Japanujo</territory>
 			<territory type="KE">Kenjo</territory>
-			<territory type="KG">Kirgizistano</territory>
+			<territory type="KG" draft="unconfirmed">Kirgizujo</territory>
 			<territory type="KH">Kamboĝo</territory>
 			<territory type="KI">Kiribato</territory>
 			<territory type="KM">Komoroj</territory>
-			<territory type="KN">Sent-Kristofo kaj Neviso</territory>
+			<territory type="KN" draft="unconfirmed">Sankta Kristoforo kaj Neviso</territory>
 			<territory type="KP">Nord-Koreo</territory>
 			<territory type="KR">Sud-Koreo</territory>
 			<territory type="KW">Kuvajto</territory>
 			<territory type="KY">Kejmanoj</territory>
-			<territory type="KZ">Kazaĥstano</territory>
+			<territory type="KZ" draft="unconfirmed">Kazaĥujo</territory>
 			<territory type="LA">Laoso</territory>
 			<territory type="LB">Libano</territory>
-			<territory type="LC">Sent-Lucio</territory>
+			<territory type="LC" draft="unconfirmed">Sankta Lucio</territory>
 			<territory type="LI">Liĥtenŝtejno</territory>
-			<territory type="LK">Sri-Lanko</territory>
+			<territory type="LK" draft="unconfirmed">Srilanko</territory>
 			<territory type="LR">Liberio</territory>
 			<territory type="LS">Lesoto</territory>
 			<territory type="LT">Litovujo</territory>
@@ -682,7 +682,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<territory type="MH">Marŝaloj</territory>
 			<territory type="MK" draft="unconfirmed">Nord-Makedonujo</territory>
 			<territory type="ML">Malio</territory>
-			<territory type="MM">Mjanmao</territory>
+			<territory type="MM" draft="unconfirmed">Birmo</territory>
 			<territory type="MN">Mongolujo</territory>
 			<territory type="MO" draft="unconfirmed">Makao</territory>
 			<territory type="MO" alt="short" draft="unconfirmed">↑↑↑</territory>
@@ -718,13 +718,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<territory type="PH">Filipinoj</territory>
 			<territory type="PK">Pakistano</territory>
 			<territory type="PL">Pollando</territory>
-			<territory type="PM">Sent-Piero kaj Mikelono</territory>
+			<territory type="PM" draft="unconfirmed">Sankta Piero kaj Mikelono</territory>
 			<territory type="PN">Pitkarna Insulo</territory>
-			<territory type="PR">Puerto-Riko</territory>
+			<territory type="PR" draft="unconfirmed">Puertoriko</territory>
 			<territory type="PS" draft="unconfirmed">Palestino</territory>
 			<territory type="PS" alt="short" draft="unconfirmed">↑↑↑</territory>
 			<territory type="PT">Portugalujo</territory>
-			<territory type="PW">Belaŭo</territory>
+			<territory type="PW" draft="unconfirmed">Palaŭo</territory>
 			<territory type="PY">Paragvajo</territory>
 			<territory type="QA">Kataro</territory>
 			<territory type="QO" draft="unconfirmed">malproksimaj insuletoj de Oceanio</territory>
@@ -733,23 +733,23 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<territory type="RS" draft="unconfirmed">Serbujo</territory>
 			<territory type="RU">Rusujo</territory>
 			<territory type="RW">Ruando</territory>
-			<territory type="SA">Saŭda Arabujo</territory>
+			<territory type="SA" draft="unconfirmed">Sauda Arabujo</territory>
 			<territory type="SB">Salomonoj</territory>
 			<territory type="SC">Sejŝeloj</territory>
 			<territory type="SD">Sudano</territory>
 			<territory type="SE">Svedujo</territory>
 			<territory type="SG">Singapuro</territory>
-			<territory type="SH">Sent-Heleno</territory>
+			<territory type="SH" draft="unconfirmed">Sankta Heleno</territory>
 			<territory type="SI">Slovenujo</territory>
-			<territory type="SJ">Svalbardo kaj Jan-Majen-insulo</territory>
+			<territory type="SJ" draft="unconfirmed">Svalbardo kaj Janmajeno</territory>
 			<territory type="SK">Slovakujo</territory>
-			<territory type="SL">Siera-Leono</territory>
-			<territory type="SM">San-Marino</territory>
+			<territory type="SL" draft="unconfirmed">Sieraleono</territory>
+			<territory type="SM" draft="unconfirmed">Sanmarino</territory>
 			<territory type="SN">Senegalo</territory>
 			<territory type="SO">Somalujo</territory>
 			<territory type="SR">Surinamo</territory>
 			<territory type="SS" draft="provisional">Sud-Sudano</territory>
-			<territory type="ST">Sao-Tomeo kaj Principeo</territory>
+			<territory type="ST" draft="unconfirmed">Santomeo kaj Principeo</territory>
 			<territory type="SV">Salvadoro</territory>
 			<territory type="SX" draft="unconfirmed">Sint-Maarten</territory>
 			<territory type="SY">Sirio</territory>
@@ -759,7 +759,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<territory type="TC" draft="unconfirmed">Turkoj kaj Kajkoj</territory>
 			<territory type="TD">Ĉado</territory>
 			<territory type="TF" draft="unconfirmed">Francaj Sudaj Teritorioj</territory>
-			<territory type="TG">Togolo</territory>
+			<territory type="TG" draft="unconfirmed">Togolando</territory>
 			<territory type="TH">Tajlando</territory>
 			<territory type="TJ">Taĝikujo</territory>
 			<territory type="TK" draft="unconfirmed">Tokelao</territory>
@@ -774,7 +774,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<territory type="TV">Tuvalo</territory>
 			<territory type="TW">Tajvano</territory>
 			<territory type="TZ">Tanzanio</territory>
-			<territory type="UA">Ukrajno</territory>
+			<territory type="UA draft="unconfirmed">Ukrainujo</territory>
 			<territory type="UG">Ugando</territory>
 			<territory type="UM">Usonaj malgrandaj insuloj</territory>
 			<territory type="UN" draft="unconfirmed">Unuiĝintaj Nacioj</territory>
@@ -783,7 +783,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<territory type="UY">Urugvajo</territory>
 			<territory type="UZ">Uzbekujo</territory>
 			<territory type="VA">Vatikano</territory>
-			<territory type="VC">Sent-Vincento kaj la Grenadinoj</territory>
+			<territory type="VC" draft="unconfirmed">Sankta Vincento kaj Grenadinoj</territory>
 			<territory type="VE">Venezuelo</territory>
 			<territory type="VG">Britaj Virgulininsuloj</territory>
 			<territory type="VI">Usonaj Virgulininsuloj</territory>
@@ -861,7 +861,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<dateFormats>
 					<dateFormatLength type="full">
 						<dateFormat>
-							<pattern>EEEE, d-'a' 'de' MMMM y G</pattern>
+							<pattern draft="unconfirmed">EEEE, 'la' d-'a' 'de' MMMM y G</pattern>
 							<datetimeSkeleton>↑↑↑</datetimeSkeleton>
 						</dateFormat>
 					</dateFormatLength>
@@ -1105,18 +1105,18 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<months>
 					<monthContext type="format">
 						<monthWidth type="abbreviated">
-							<month type="1">jan</month>
-							<month type="2">feb</month>
-							<month type="3">mar</month>
-							<month type="4">apr</month>
-							<month type="5">maj</month>
-							<month type="6">jun</month>
-							<month type="7">jul</month>
-							<month type="8">aŭg</month>
-							<month type="9">sep</month>
-							<month type="10">okt</month>
-							<month type="11">nov</month>
-							<month type="12">dec</month>
+							<month type="1">Jan</month>
+							<month type="2">Feb</month>
+							<month type="3">Mar</month>
+							<month type="4">Apr</month>
+							<month type="5">Maj</month>
+							<month type="6">Jun</month>
+							<month type="7">Jul</month>
+							<month type="8">Aŭg</month>
+							<month type="9">Sep</month>
+							<month type="10">Okt</month>
+							<month type="11">Nov</month>
+							<month type="12">Dec</month>
 						</monthWidth>
 						<monthWidth type="narrow">
 							<month type="1" draft="unconfirmed">↑↑↑</month>
@@ -1133,18 +1133,18 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<month type="12" draft="unconfirmed">↑↑↑</month>
 						</monthWidth>
 						<monthWidth type="wide">
-							<month type="1">januaro</month>
-							<month type="2">februaro</month>
-							<month type="3">marto</month>
-							<month type="4">aprilo</month>
-							<month type="5">majo</month>
-							<month type="6">junio</month>
-							<month type="7">julio</month>
-							<month type="8">aŭgusto</month>
-							<month type="9">septembro</month>
-							<month type="10">oktobro</month>
-							<month type="11">novembro</month>
-							<month type="12">decembro</month>
+							<month type="1">Januaro</month>
+							<month type="2">Februaro</month>
+							<month type="3">Marto</month>
+							<month type="4">Aprilo</month>
+							<month type="5">Majo</month>
+							<month type="6">Junio</month>
+							<month type="7">Julio</month>
+							<month type="8">Aŭgusto</month>
+							<month type="9">Septembro</month>
+							<month type="10">Oktobro</month>
+							<month type="11">Novembro</month>
+							<month type="12">Decembro</month>
 						</monthWidth>
 					</monthContext>
 					<monthContext type="stand-alone">
@@ -1344,28 +1344,28 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</dayPeriods>
 				<eras>
 					<eraNames>
-						<era type="0">↑↑↑</era>
+						<era type="0" draft="unconfirmed">antaŭ nia erao</era>
 						<era type="0" alt="variant" draft="unconfirmed">antaŭ Kristo</era>
-						<era type="1">↑↑↑</era>
+						<era type="1" draft="unconfirmed">de nia erao</era>
 						<era type="1" alt="variant" draft="unconfirmed">post Kristo</era>
 					</eraNames>
 					<eraAbbr>
-						<era type="0">aK</era>
+						<era type="0" draft="unconfirmed">a.n.e.</era>
 						<era type="0" alt="variant" draft="unconfirmed">a.K.</era>
-						<era type="1">pK</era>
+						<era type="1" draft="unconfirmed">n.e.</era>
 						<era type="1" alt="variant" draft="unconfirmed">p.K.</era>
 					</eraAbbr>
 					<eraNarrow>
 						<era type="0">↑↑↑</era>
-						<era type="0" alt="variant">aK</era>
+						<era type="0" alt="variant">↑↑↑</era>
 						<era type="1">↑↑↑</era>
-						<era type="1" alt="variant" draft="unconfirmed">KE</era>
+						<era type="1" alt="variant" draft="unconfirmed">↑↑↑</era>
 					</eraNarrow>
 				</eras>
 				<dateFormats>
 					<dateFormatLength type="full">
 						<dateFormat>
-							<pattern>EEEE, d-'a' 'de' MMMM y</pattern>
+							<pattern draft="unconfirmed">EEEE, 'la' d-'a' 'de' MMMM y</pattern>
 							<datetimeSkeleton>↑↑↑</datetimeSkeleton>
 						</dateFormat>
 					</dateFormatLength>
@@ -1391,7 +1391,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<timeFormats>
 					<timeFormatLength type="full">
 						<timeFormat>
-							<pattern>H-'a' 'horo' 'kaj' m:ss zzzz</pattern>
+							<pattern draft="unconfirmed">HH:mm:ss zzzz</pattern>
 							<datetimeSkeleton>Hmsszzzz</datetimeSkeleton>
 						</timeFormat>
 					</timeFormatLength>


### PR DESCRIPTION
CLDR-15878

- [X] This PR completes the ticket.

I corrected numerous wrongly confirmed items, which couldn't be corrected using the Survey Tool.
- word “mondo” minuscule
- names of countries according to the list of [Bertilo](https://bertilow.com/lanlin/index.html) (and [AdE](https://www.akademio-de-esperanto.org/decidoj/landnomoj/listo_de_rekomendataj_landnomoj/))
- names of languages (mostly) according to the list of [Bertilo](https://bertilow.com/lanlin/lingvoj.html)
- [capitalized months](https://bertilow.com/pmeg/gramatiko/propraj_nomoj/majuskloj.html#i-klc) and names of languages according to recommends in [PMEG](https://bertilow.com/pmeg/gramatiko/propraj_nomoj/landoj_popoloj_lingvoj.html#i-bzv)
- nonreligious terms (_de nia erao/antaŭ nia erao_) for eras and religious terms as variants (_post Kristo/antaŭ Kristo_)
- fixed full date pattern (added _la_)
- fixed uncommon full time pattern

Changes are marked as "unconfirmed", so any contributor could change them during the next submitting phase in ST.

ALLOW_MANY_COMMITS=true
